### PR TITLE
docs: add project:remove command and update project management docs

### DIFF
--- a/docs/getting-started/command-reference.md
+++ b/docs/getting-started/command-reference.md
@@ -546,7 +546,8 @@ redeployment.
 
 ## RAG Knowledge Store Commands
 
-Commands for managing the RAG (Retrieval-Augmented Generation) knowledge store. These commands require RAG to be configured in your `context.yaml`.
+Commands for managing the RAG (Retrieval-Augmented Generation) knowledge store. These commands require RAG to be
+configured in your `context.yaml`.
 
 ### Check RAG Status
 
@@ -558,9 +559,9 @@ ctx rag:status
 
 #### Options
 
-| Option   | Description      |
-|----------|------------------|
-| `--json` | Output as JSON   |
+| Option   | Description    |
+|----------|----------------|
+| `--json` | Output as JSON |
 
 ```bash
 ctx rag:status --json
@@ -576,12 +577,12 @@ ctx rag:index <path>
 
 #### Options
 
-| Option        | Short | Default   | Description                                    |
-|---------------|-------|-----------|------------------------------------------------|
-| `--pattern`   | `-p`  | `*.md`    | File pattern (e.g., `*.php`, `*.md`)           |
-| `--type`      | `-t`  | `general` | Document type (see below)                      |
-| `--recursive` | `-r`  | `true`    | Search recursively                             |
-| `--dry-run`   |       | `false`   | Preview files without indexing                 |
+| Option        | Short | Default   | Description                          |
+|---------------|-------|-----------|--------------------------------------|
+| `--pattern`   | `-p`  | `*.md`    | File pattern (e.g., `*.php`, `*.md`) |
+| `--type`      | `-t`  | `general` | Document type (see below)            |
+| `--recursive` | `-r`  | `true`    | Search recursively                   |
+| `--dry-run`   |       | `false`   | Preview files without indexing       |
 
 **Document types:** `architecture`, `api`, `testing`, `convention`, `tutorial`, `reference`, `general`
 
@@ -611,9 +612,9 @@ ctx rag:clear
 
 #### Options
 
-| Option    | Short | Description                 |
-|-----------|-------|-----------------------------|
-| `--force` | `-f`  | Skip confirmation prompt    |
+| Option    | Short | Description              |
+|-----------|-------|--------------------------|
+| `--force` | `-f`  | Skip confirmation prompt |
 
 ```bash
 ctx rag:clear -f
@@ -629,12 +630,12 @@ ctx rag:reindex <path>
 
 #### Options
 
-| Option        | Short | Default   | Description                        |
-|---------------|-------|-----------|-----------------------------------|
-| `--pattern`   | `-p`  | `*.md`    | File pattern                      |
-| `--type`      | `-t`  | `general` | Document type                     |
-| `--recursive` | `-r`  | `true`    | Search recursively                |
-| `--force`     | `-f`  | `false`   | Skip confirmation prompt          |
+| Option        | Short | Default   | Description              |
+|---------------|-------|-----------|--------------------------|
+| `--pattern`   | `-p`  | `*.md`    | File pattern             |
+| `--type`      | `-t`  | `general` | Document type            |
+| `--recursive` | `-r`  | `true`    | Search recursively       |
+| `--force`     | `-f`  | `false`   | Skip confirmation prompt |
 
 #### Examples
 
@@ -647,3 +648,139 @@ ctx rag:reindex docs -f
 ```
 
 > **Note:** For detailed RAG configuration and MCP tool usage, see the [RAG Knowledge Store](/mcp/rag) documentation.
+
+## Project Management Commands
+
+Commands for managing multiple projects. These allow you to register, switch between, list, and remove projects from the
+CTX registry.
+
+> **Note:** For detailed project management information, see the [Dynamic Project Switching](/mcp/projects)
+> documentation.
+
+### Add a Project (`project:add`)
+
+Register a new project with the system:
+
+```bash
+ctx project:add <path> [--name=<alias>] [--config-file=<path>] [--env-file=<path>] [--switch]
+```
+
+#### Arguments
+
+| Argument | Description                                                   |
+|----------|---------------------------------------------------------------|
+| `path`   | Path to the project directory. Use `.` for current directory. |
+
+#### Options
+
+| Option          | Short | Description                                          |
+|-----------------|-------|------------------------------------------------------|
+| `--name`        |       | Alias name for the project                           |
+| `--config-file` | `-c`  | Path to custom configuration file within the project |
+| `--env-file`    | `-e`  | Path to .env file within the project                 |
+| `--switch`      | `-s`  | Switch to this project after adding it               |
+
+#### Examples
+
+```bash
+# Add current directory as a project
+ctx project:add . --name=my-project
+
+# Add with custom configuration
+ctx project:add /path/to/project --name=backend --env-file=.env.dev
+
+# Add and switch to the project
+ctx project:add . --name=frontend --switch
+```
+
+### Switch Project (`project`)
+
+Switch to a different registered project:
+
+```bash
+ctx project [<path_or_alias>]
+```
+
+#### Arguments
+
+| Argument        | Description                                                       |
+|-----------------|-------------------------------------------------------------------|
+| `path_or_alias` | Path or alias to the project. If omitted, shows interactive menu. |
+
+#### Examples
+
+```bash
+# Switch using alias
+ctx project my-backend
+
+# Switch using path
+ctx project /path/to/project
+
+# Interactive selection
+ctx project
+```
+
+### List Projects (`project:list`)
+
+View all registered projects:
+
+```bash
+ctx project:list
+# or
+ctx projects
+```
+
+#### Example Output
+
+```
+╭─● CURRENT ─────────────────────────────────────────────────────────╮
+│  /home/user/projects/my-app
+│  Aliases: my-app
+│  Added: Jan 18, 2025
+╰────────────────────────────────────────────────────────────────────╯
+
+╭─○──────────────────────────────────────────────────────────────────╮
+│  /home/user/projects/backend
+│  Aliases: backend
+│  Added: Jan 15, 2025
+╰────────────────────────────────────────────────────────────────────╯
+
+Commands:
+  ctx project <path|alias>         Switch to a project
+  ctx project:add <path>           Add a new project
+  ctx project:remove <path|alias>  Remove a project
+```
+
+### Remove a Project (`project:remove`)
+
+Remove a project from the registry:
+
+```bash
+ctx project:remove [<path_or_alias>] [--force]
+```
+
+#### Arguments
+
+| Argument        | Description                                                       |
+|-----------------|-------------------------------------------------------------------|
+| `path_or_alias` | Path or alias to the project. If omitted, shows interactive menu. |
+
+#### Options
+
+| Option           | Short | Description                                  |
+|------------------|-------|----------------------------------------------|
+| `--force`        | `-f`  | Skip confirmation prompt                     |
+| `--keep-aliases` |       | Keep aliases when removing (not recommended) |
+
+#### Examples
+
+```bash
+# Remove by alias
+ctx project:remove my-backend
+
+# Remove without confirmation
+ctx project:remove old-project --force
+
+# Interactive selection
+ctx project:remove
+```

--- a/docs/mcp/projects.md
+++ b/docs/mcp/projects.md
@@ -29,12 +29,12 @@ When the `-c` option is omitted, CTX will use the globally registered projects c
 
 CTX provides several commands for managing your projects:
 
-## Adding a Project (`project:add`)
+### Adding a Project (`project:add`)
 
 Register a new project with the system:
 
 ```bash
-ctx project:add <path> [--name=<alias>] [--config-file=<path>] [--env-file=<path>]
+ctx project:add <path> [--name=<alias>] [--config-file=<path>] [--env-file=<path>] [--switch]
 ```
 
 **Example:**
@@ -60,8 +60,23 @@ ctx project:add . --name=my-backend --env-file=.env.dev
 - `--name`: Alias name for the project (optional)
 - `--config-file` or `-c`: Path to custom configuration file within the project (optional)
 - `--env-file` or `-e`: Path to .env file within the project (optional)
+- `--switch` or `-s`: Switch to this project after adding it (optional)
 
-## Switching Between Projects (`project`)
+**Example output:**
+
+```
+  ✓ Project added successfully
+
+╭─● CURRENT ─────────────────────────────────────────────────────────╮
+│  /home/user/projects/my-backend
+│  Aliases: my-backend
+│  Added: Jan 18, 2025
+╰────────────────────────────────────────────────────────────────────╯
+
+  → Set as current project (first project added)
+```
+
+### Switching Between Projects (`project`)
 
 Switch to a different registered project:
 
@@ -93,6 +108,13 @@ or you can omit the argument to see a list of all registered projects:
 ctx project
 ```
 
+**Example output:**
+
+```
+  ✓ Switched to project: /home/user/projects/my-backend
+    Aliases: my-backend
+```
+
 ### Listing Projects (`project:list` or `projects`)
 
 View all registered projects:
@@ -104,16 +126,99 @@ ctx project:list
 **Example output:**
 
 ```
-┌─────────────────────────────┬────────────────────┬──────────┬─────────────────┬─────────────────┬─────────┐
-│ Path                        │ Config File        │ Env File │ Aliases         │ Added           │ Current │
-├─────────────────────────────┼────────────────────┼──────────┼─────────────────┼─────────────────┼─────────┤
-│ /home/user/projects/my-app  │                    │          │ my-app          │ 2025-05-01 10:15│         │
-├─────────────────────────────┼────────────────────┼──────────┼─────────────────┼─────────────────┼─────────┤
-│ /home/user/projects/backend │ custom-context.yaml│ .env.dev │ my-backend,     │ 2025-05-01 14:30│ active  │
-│                             │                    │          │ backend         │                 │         │
-├─────────────────────────────┼────────────────────┼──────────┼─────────────────┼─────────────────┼─────────┤
-│ /home/user/projects/frontend│                    │          │ my-ui           │ 2025-05-02 09:45│         │
-└─────────────────────────────┴────────────────────┴──────────┴─────────────────┴─────────────────┴─────────┘
+╭─● CURRENT ─────────────────────────────────────────────────────────╮
+│  /home/user/projects/my-app
+│  Aliases: my-app
+│  Config: context.yaml
+│  Added: Jan 18, 2025
+╰────────────────────────────────────────────────────────────────────╯
+
+╭─○──────────────────────────────────────────────────────────────────╮
+│  /home/user/projects/backend
+│  Aliases: my-backend, backend
+│  Config: custom-context.yaml
+│  Env: .env.dev
+│  Added: Jan 15, 2025
+╰────────────────────────────────────────────────────────────────────╯
+
+╭─○──────────────────────────────────────────────────────────────────╮
+│  /home/user/projects/frontend
+│  Aliases: my-ui
+│  Added: Jan 10, 2025
+╰────────────────────────────────────────────────────────────────────╯
+
+Commands:
+  ctx project <path|alias>         Switch to a project
+  ctx project:add <path>           Add a new project
+  ctx project:remove <path|alias>  Remove a project
+```
+
+The output uses visual indicators:
+
+- `●` (green) — Current active project
+- `○` (gray) — Other registered projects
+
+### Removing a Project (`project:remove`)
+
+Remove a project from the registry:
+
+```bash
+ctx project:remove [<path_or_alias>] [--force] [--keep-aliases]
+```
+
+**Arguments:**
+
+- `path_or_alias`: Path or alias to the project (optional). If omitted, displays an interactive selection menu.
+
+**Options:**
+
+- `--force` or `-f`: Skip confirmation prompt
+- `--keep-aliases`: Keep aliases when removing project (not recommended)
+
+**Example:**
+
+Remove a project using its alias:
+
+```bash
+ctx project:remove my-backend
+```
+
+Remove without confirmation:
+
+```bash
+ctx project:remove my-backend --force
+```
+
+Interactive selection (when no argument provided):
+
+```bash
+ctx project:remove
+```
+
+**Example output:**
+
+```
+╭─○──────────────────────────────────────────────────────────────────╮
+│  /home/user/projects/old-project
+│  Aliases: old-project
+│  Added: Jan 10, 2025
+╰────────────────────────────────────────────────────────────────────╯
+
+  Are you sure you want to remove this project? [y/N] y
+
+  ✓ Project removed: /home/user/projects/old-project
+  → Aliases removed: old-project
+```
+
+If you remove the current project, CTX will suggest switching to another:
+
+```
+  ! This is the current project. It will be unset after removal.
+
+  ✓ Project removed: /home/user/projects/my-app
+  → Aliases removed: my-app
+
+  → Use ctx project my-backend to switch to another project
 ```
 
 ## Configuring MCP Server for Project Switching


### PR DESCRIPTION
Document new project:remove command and update all project management documentation to reflect the new card-based UX.

Changes to docs/mcp/projects.md:
- Add project:remove command documentation with all options
- Update all command examples with new card-based output format
- Add visual indicator explanation (● current, ○ other)
- Document --switch option for project:add

Changes to docs/getting-started/command-reference.md:
- Add new "Project Management Commands" section
- Document all 4 project commands with options and examples
- Add link to detailed project switching documentation